### PR TITLE
Bump libesvm version

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "cli-color": "^0.3.2",
     "cli-table": "^0.3.1",
     "commander": "^2.3.0",
-    "libesvm": "^3.6.5",
+    "libesvm": "^3.7.2",
     "lodash": "^4.0.0",
     "moment": "^2.8.1",
     "optimist": "^0.6.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "esvm",
-  "version": "3.2.11",
+  "version": "3.3.0",
   "description": "Elasticsearch Version Manager",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
I was hoping that bumping `libesvm` would provide me with installable ES versions that were greater than 2.4.0, but that doesn't seem to be the case. Needed to be done anyway, so here ya go.